### PR TITLE
Fix minor typos

### DIFF
--- a/asgi_tools/_compat.py
+++ b/asgi_tools/_compat.py
@@ -1,4 +1,4 @@
-"""Compatability layer."""
+"""Compatibility layer."""
 
 from __future__ import annotations
 
@@ -138,7 +138,7 @@ async def aio_timeout(timeout: float):  # noqa: ASYNC109
 
 
 async def aio_wait(*aws: Awaitable, strategy: str = ALL_COMPLETED) -> Any:
-    """Run the coros concurently, wait for all completed or cancel others.
+    """Run the coros concurrently, wait for all completed or cancel others.
 
     Only ALL_COMPLETED, FIRST_COMPLETED are supported.
     """

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -231,7 +231,7 @@ ResponseStream
     .. code-block:: python
 
         from asgi_tools import ResponseStream
-        from asgi_tools.utils import aio_sleep  # for compatability with different async libs
+        from asgi_tools.utils import aio_sleep  # for compatibility with different async libs
 
         async def stream_response():
             for number in range(10):
@@ -251,7 +251,7 @@ ResponseSSE
     .. code-block:: python
 
         from asgi_tools import ResponseSSE
-        from asgi_tools.utils import aio_sleep  # for compatability with different async libs
+        from asgi_tools.utils import aio_sleep  # for compatibility with different async libs
 
         async def stream_response():
             for number in range(10):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -181,7 +181,7 @@ async def test_docs_response_error(client_cls):
 
 async def test_docs_response_stream(client_cls):
     from asgi_tools import ResponseStream
-    from asgi_tools._compat import aio_sleep  # for compatability with different async libs
+    from asgi_tools._compat import aio_sleep  # for compatibility with different async libs
 
     async def stream_response():
         for number in range(10):


### PR DESCRIPTION
## Summary
- correct typos in compatibility helpers, docs and tests

## Testing
- `ruff check asgi_tools/_compat.py`
- `black asgi_tools/_compat.py tests/test_examples.py`
- `pytest tests/test_examples.py::test_docs_response_stream -q` *(fails: ModuleNotFoundError: No module named 'http_router')*
- `make -C docs html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bddaf63888333b83e3a03a933c88d