### PR TITLE
Fix typo Despite

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ A Quick Example
 
 You can use any of ASGI-Tools components independently.
 
-Dispite this ASGI-Tools contains App_ helper to quickly build ASGI
+Despite this ASGI-Tools contains App_ helper to quickly build ASGI
 applications. For instance:
 
 Save this to ``app.py``.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,7 +5,7 @@ ASGI Application
 -----------------
 
 ASGI-Tools is designed to be used as an ASGI_ Toolkit. You can use any of its
-components independently. Dispite this ASGI-Tools contains
+components independently. Despite this ASGI-Tools contains
 :py:class:`asgi_tools.App` helper to quickly build ASGI applications.
 
 .. note::


### PR DESCRIPTION
## Summary
- fix a typo: Dispite -> Despite in README and docs

## Testing
- `pytest -vv tests/test_utils.py` *(fails: ModuleNotFoundError: http_router)*
- `make docs` *(fails: Could not find a version that satisfies the requirement setuptools)*

------
https://chatgpt.com/codex/tasks/task_b_683bddb3cef48333a3ad69025fa81eaa