### PR TITLE
Fix typo in Request media property

### DIFF
--- a/asgi_tools/request.py
+++ b/asgi_tools/request.py
@@ -177,8 +177,8 @@ class Request(TASGIScope):
     def media(self) -> dict[str, str]:
         """Prepare a media data for the request."""
         if self._media is None:
-            conten_type_header = self.headers.get("content-type", "")
-            content_type, opts = parse_options_header(conten_type_header)
+            content_type_header = self.headers.get("content-type", "")
+            content_type, opts = parse_options_header(content_type_header)
             self._media = dict(opts, content_type=content_type)
 
         return self._media


### PR DESCRIPTION
## Summary
- correct typo in `Request.media`

## Testing
- `ruff check asgi_tools` *(fails: `__all__` not sorted)*
- `mypy` *(fails: Could not find `types-ujson`)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'http_router')*

------
https://chatgpt.com/codex/tasks/task_b_683bddba54f08333bf9464ce08bfadf5