### PR TITLE
Fix docstring example

### DIFF
--- a/asgi_tools/middleware.py
+++ b/asgi_tools/middleware.py
@@ -368,7 +368,7 @@ class StaticFilesMiddleware(BaseMiddeware):
         from asgi_tools import StaticFilesMiddleware, ResponseHTML
 
         async def app(scope, receive, send):
-            response = ResponseHTML('OK)
+            response = ResponseHTML('OK')
             await response(scope, receive, send)
 
         # Files from static folder will be served from /static


### PR DESCRIPTION
## Summary
- correct `StaticFilesMiddleware` doc example

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'http_router')*
- `make -C docs html` *(fails: sphinx-build not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bddbf8b3883339e99aaabd3fc8b5f