### PR TITLE
Fix tox envlist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ ignore_missing_imports = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py39,py310,py311,py312,py313,,pypy310
+envlist = py39,py310,py311,py312,py313,pypy310
 
 [testenv]
 deps = -e .[tests]


### PR DESCRIPTION
## Summary
- update `envlist` in `pyproject.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'http_router')*

------
https://chatgpt.com/codex/tasks/task_b_683bddc811b4833399c957c0a2109be3