### PR TITLE
Use bytearray in Request.body

### DIFF
--- a/asgi_tools/request.py
+++ b/asgi_tools/request.py
@@ -232,7 +232,10 @@ class Request(TASGIScope):
         `body = await request.body()`
         """
         if self._body is None:
-            self._body = b"".join([chunk async for chunk in self.stream()])
+            data = bytearray()
+            async for chunk in self.stream():
+                data.extend(chunk)
+            self._body = bytes(data)
 
         return self._body
 


### PR DESCRIPTION
## Summary
- use a `bytearray` accumulator in `Request.body`
- remove previously-added stub modules

## Testing
- `pytest tests/test_client.py::test_build_scope -q` *(fails: ModuleNotFoundError for http_router)*
- `pytest tests/test_request.py::test_body -q` *(fails: ModuleNotFoundError for http_router)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_683bddcce7cc8333b6f8d15a5ca0b59c